### PR TITLE
Remove Japanese from gemspec.

### DIFF
--- a/ubi_graphviz.gemspec
+++ b/ubi_graphviz.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["jiikko"]
   spec.email         = ["n905i.1214@gmail.com"]
 
-  spec.summary       = %q{DOT言語のコードを生成します.}
+  spec.summary       = %q{Generate code of DOT language.}
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/jiikko/ubi-graphviz"
   spec.license       = "MIT"


### PR DESCRIPTION
On some of environment, especially Docker, bundler cannot install a gem have non ascii character in gemspec.

```
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/dsl.rb:586:in `parse_line_number_from_description': invalid byte sequence in US-ASCII (ArgumentError)
```

We can avoidance this error with setting environment variable.
But I think gemspec should not have non ascii characters.